### PR TITLE
Add take_or_clone_val

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cactus"
 description = "Immutable cactus stack"
 repository = "https://github.com/softdevteam/cactus/"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license-file = "LICENSE"


### PR DESCRIPTION
When one is popping back up a cactus stack, it's common to want access to a node's data just before it is dropped. Via the `val()` method one has no choice but to `clone()` data. However, if the node has no children one can safely consume the node and move the `val` data to the caller. This method puts this under one hood: if possible the `val` data is moved, otherwise it is cloned.