### PR TITLE
Use the precedent of Rc::try_unwrap instead of the custom "take_or_clone_val"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cactus"
 description = "Immutable cactus stack"
 repository = "https://github.com/softdevteam/cactus/"
-version = "0.1.1"
+version = "1.0.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license-file = "LICENSE"


### PR DESCRIPTION
**DON'T MERGE YET**

`take_or_clone_val` has two problems: 1) if you don't want to clone the value if the take fails, tough luck 2) it's a non-standard API.

This commit tentatively remodels the API along the lines of the standard library's `Rc::try_unwrap`. This has the virtue of familiarity and flexibility, but if you want to clone it's more of a pain. This:

```rust
  let x = cactus.take_or_clone_val().unwrap();
```

becomes:

```rust
  let x = cactus.try_unwrap().unwrap_or_else(|c| c.val().unwrap().clone())
```

I welcome thoughts as to whether this is a good idea orr not. I'm unsure.