### PR TITLE
Manually unroll the zip() in eq() to allow us to use Rc::ptr_eq.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cactus"
 description = "Immutable cactus stack"
 repository = "https://github.com/softdevteam/cactus/"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license-file = "LICENSE"


### PR DESCRIPTION
Two cactuses are trivially equal if their two Rc's compare true with Rc::ptr_eq. For large cactuses created from the same root, this is a potentially large saving, as comparisons move from a best case of O(n) to O(1) (though the worst case is still O(n)).
