### PR TITLE
Make len() an O(n) operation (again).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cactus"
 description = "Immutable cactus stack"
 repository = "https://github.com/softdevteam/cactus/"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license-file = "LICENSE"


### PR DESCRIPTION
I moved len() from O(n) to O(1) by storing a usize `len` field. This seemed like a good idea and probably is on very large cactuses for which one regularly asks the length of. But this no longer seems a very common use case to me. Instead, I suspect most cactuses are relatively shallow in depth, albeit potentially rather broad.

Indeed, that's the use case I have. Removing the `len` field on a 64-bit machine saves 8 bytes. On one program I have which makes heavy use of cactuses (but which I did not expect cactus costs to dominate), lessening the pressure on the memory systems leads to a 10% performance gain (even though the code occasionally calls len(), or does equivalent operations).

It might be possible -- if anyone really, really wants it -- to make len() O(1) in some case by doing pointer fiddling. [On amd64, if you know what you're doing, there are 16 spare bits in a pointer. This would involve manually implementing the equivalent of Option. Is it worth it? Not to me it isn't, at least not yet.]