### PR TITLE
Move to Apache-2 / MIT / UPL.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,12 @@
 name = "cactus"
 description = "Immutable cactus stack"
 repository = "https://github.com/softdevteam/cactus/"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
-license-file = "LICENSE"
+# This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about
+# UPL-1.0.
+license = "Apache-2.0 OR MIT"
 categories = ["data-structures"]
 
 [lib]

--- a/LICENSE
+++ b/LICENSE
@@ -1,31 +1,4 @@
-Copyright (c) 2017 King's College London
-created by the Software Development Team <http://soft-dev.org/>
-
-The Universal Permissive License (UPL), Version 1.0
-
-Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-copy of this software, associated documentation and/or data (collectively the "Software"), free
-of charge and under any and all copyright rights in the Software, and any and all patent rights
-owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-below), to deal in both
-
-(a) the Software, and
-(b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-if one is included with the Software (each a "Larger Work" to which the Software is contributed
-by such licensors),
-
-without restriction, including without limitation the rights to copy, create derivative works
-of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-foregoing rights on either these or other terms.
-
-This license is subject to the following condition: The above copyright notice and either this
-complete permission notice or at a minimum a reference to the UPL must be included in all copies
-or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Except as otherwise noted, this project is licensed under the Apache License,
+Version 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, or
+the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>, or the
+UPL-1.0 license <http://opensource.org/licenses/UPL> at your option.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,11 @@
-// Copyright (c) 2017 King's College London
-// created by the Software Development Team <http://soft-dev.org/>
+// Copyright (c) 2018 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
 //
-// The Universal Permissive License (UPL), Version 1.0
-//
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
-// copy of this software, associated documentation and/or data (collectively the "Software"), free
-// of charge and under any and all copyright rights in the Software, and any and all patent rights
-// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
-// below), to deal in both
-//
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
-// if one is included with the Software (each a "Larger Work" to which the Software is contributed
-// by such licensors),
-//
-// without restriction, including without limitation the rights to copy, create derivative works
-// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
-// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
-// foregoing rights on either these or other terms.
-//
-// This license is subject to the following condition: The above copyright notice and either this
-// complete permission notice or at a minimum a reference to the UPL must be included in all copies
-// or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
 
 //! An immutable cactus stuck (also called a spaghetti stack or parent pointer tree). A cactus
 //! stack is a (possibly empty) node with a (possibly null) pointer to a parent node. Any given


### PR DESCRIPTION
Move to our new triple license approach for Rust libraries. No functional change.