### PR TITLE
2018 edition update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,29 @@
+# cactus 1.0.4 (2018-12-18)
+
+* Ported to Rust 2018.
+
+
+# cactus 1.0.3 (2018-04-04)
+
+* Triple licence Apache-2 / MIT / UPL.
+
+
+# cactus 1.0.2 (2018-02-05)
+
+* Cactuses are now hashable.
+
+* Remove take_or_clone_val() and replace it with try_unwrap, modelled on
+  Rc::try_unwrap.
+
+* Shortcut eq() comparison with Rc::ptr_eq, turning the best case comparison
+  from O(n) to O(1) (though the worst case remains O(n)).
+
+
+# cactus 1.0.1 (2018-02-01)
+
+* Tentatively add take_or_clone_val().
+
+
+# cactus 1.0.0 (2017-10-10)
+
+First stable release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cactus"
-description = "Immutable cactus stack"
+description = "Immutable parent pointer tree"
 repository = "https://github.com/softdevteam/cactus/"
 version = "1.0.3"
 authors = ["Laurence Tratt <laurie@tratt.net>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cactus"
 description = "Immutable parent pointer tree"
 repository = "https://github.com/softdevteam/cactus/"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 # This should be "Apache-2.0 OR MIT OR UPL-1.0" but crates.io doesn't know about

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 # UPL-1.0.
 license = "Apache-2.0 OR MIT"
 categories = ["data-structures"]
+edition = "2018"
 
 [lib]
 name = "cactus"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,12 +267,12 @@ impl<T: Hash> Hash for Cactus<T> {
 
 impl<T: fmt::Debug> fmt::Debug for Cactus<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "Cactus["));
+        write!(f, "Cactus[")?;
         for (i, x) in self.vals().enumerate() {
             if i > 0 {
-                try!(write!(f, ", "));
+                write!(f, ", ")?;
             }
-            try!(write!(f, "{:?}", x));
+            write!(f, "{:?}", x)?;
         }
         write!(f, "]")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,10 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-//! An immutable cactus stuck (also called a spaghetti stack or parent pointer tree). A cactus
-//! stack is a (possibly empty) node with a (possibly null) pointer to a parent node. Any given
-//! node has a unique path back to the root node. Rather than mutably updating the stack, one
+//! An immutable parent pointer tree -- also called a cactus stack.
+//!
+//! A cactus stack is a (possibly empty) node with a (possibly null) pointer to a parent node. Any
+//! given node has a unique path back to the root node. Rather than mutably updating the stack, one
 //! creates and obtains access to immutable nodes (when a node becomes unreachable its memory is
 //! automatically reclaimed). A new child node pointing to a parent can be created via the `child`
 //! function (analogous to the normal `push`) and a parent can be retrieved via the `parent`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,16 +243,16 @@ impl<T: PartialEq> PartialEq for Cactus<T> {
             if sn.val != on.val {
                 return false;
             }
-            si.take().map(|n| si = n.parent.as_ref());
-            oi.take().map(|n| oi = n.parent.as_ref());
+            if let Some(n) = si.take() {
+                si = n.parent.as_ref();
+            }
+            if let Some(n) = oi.take() {
+                oi = n.parent.as_ref();
+            }
         }
-        if si.is_some() || oi.is_some() {
-            // One of the iterators finished before the other, meaning that the two cactuses were
-            // of different length and thus unequal by definition
-            false
-        } else {
-            true
-        }
+        // If one of the iterators finished before the other, the two cactuses were of different
+        // length and thus unequal by definition; otherwise they were equal.
+        !(si.is_some() || oi.is_some())
     }
 }
 


### PR DESCRIPTION
Ports the cactus crate to Rust 2018, makes a few minor improvements, and -- assuming you think it's ready -- make a new release. The changes herein are all very minor, but they keep the library fresh-ish.